### PR TITLE
[Codex] Fix #11: Runner dead code in failure branch

### DIFF
--- a/src/agentflow/services/runner.py
+++ b/src/agentflow/services/runner.py
@@ -105,7 +105,7 @@ class Runner:
             self.store.finalize_run(
                 run_id,
                 "failed",
-                gate_passed=False,
+                gate_passed=gate_passed,
                 result_summary=message,
                 error_code=error_code,
             )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -70,6 +70,32 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual("blocked", record.task.status)
         self.assertFalse(record.success)
 
+    def test_run_once_execution_failure_preserves_gate_passed_state(self) -> None:
+        task_id = self.store.add_task(
+            project="demo",
+            title="investigate flaky failure",
+            description=None,
+            priority=5,
+            impact=5,
+            effort=2,
+            source="github",
+            external_id="102",
+        )
+        runner = Runner(self.store, AdapterRegistry())
+        record = runner.run_once("demo", "mock", "codex-worker")
+
+        self.assertIsNotNone(record.task)
+        assert record.task is not None
+        self.assertEqual(task_id, record.task.id)
+        self.assertEqual("blocked", record.task.status)
+        self.assertFalse(record.success)
+
+        runs = self.store.list_runs(task_id)
+        self.assertEqual(1, len(runs))
+        self.assertEqual("failed", runs[0]["status"])
+        self.assertEqual(1, runs[0]["gate_passed"])
+        self.assertEqual("execution_failed", runs[0]["error_code"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- verify issue #11 failure-path behavior in Runner._run_claimed_task
- fix incorrect gate_passed persistence in failed runs when execution fails but gate passes
- add regression test to lock execution_failed plus gate_passed=1 semantics

## Verification
- PYTHONPATH=src python3 -m unittest discover -s tests -p 'test_*.py'

Fixes #11