### PR TITLE
harden gate command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ Stage Board + Task Detail demo (illustrative, single image):
 - Run orchestration (`run-once`, `run-batch`) with adapter protocol
 - Trigger idempotency and event ingestion (`discover-issues`, `handle-comment`)
 - Periodic GitHub pull ingestion (`sync-issues`)
-- Gate enforcement with command checks and blocked-on-fail behavior
+- Gate enforcement with argv-safe command execution and blocked-on-fail behavior
+  - Gate commands may be stored as legacy strings or structured templates like `{"command":"...", "args":[...]}`; structured templates are preferred
+  - Strict allowlist mode is enabled by default via `AGENTFLOW_GATE_STRICT_ALLOWLIST=1`
   - Optional safety controls: `AGENTFLOW_GATE_ALLOWED_PREFIXES`
+  - Opt out of strict allowlisting with `AGENTFLOW_GATE_STRICT_ALLOWLIST=0`
   - Optional workspace root: `AGENTFLOW_WORKSPACE_ROOT` (for gate `cwd` resolution)
 
 ### Web Console

--- a/src/agentflow/services/gates.py
+++ b/src/agentflow/services/gates.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
+import shlex
 import subprocess
 from dataclasses import dataclass
-from typing import Sequence
+from collections.abc import Mapping, Sequence
 
 
 @dataclass
@@ -26,31 +28,50 @@ class GateEvaluator:
         *,
         cwd: str | None = None,
         allowed_prefixes: Sequence[str] | None = None,
+        strict_allowlist: bool = True,
     ) -> None:
         self.timeout_sec = timeout_sec
         self.cwd = cwd
         self.allowed_prefixes = [p.strip() for p in (allowed_prefixes or []) if str(p).strip()]
+        self.strict_allowlist = strict_allowlist
 
-    def evaluate(self, commands: list[str]) -> GateResult:
+    def evaluate(self, commands: Sequence[object]) -> GateResult:
         checks: list[GateCheckResult] = []
         overall = True
 
         for command in commands:
-            if self.allowed_prefixes and not self._is_allowed(command):
+            parsed = self._parse_command(command)
+            if parsed is None:
                 overall = False
                 checks.append(
                     GateCheckResult(
-                        command=command,
+                        command=self._command_label(command),
+                        passed=False,
+                        exit_code=2,
+                        output=f"invalid gate command template: {self._command_label(command)}",
+                    )
+                )
+                break
+            argv, command_label = parsed
+
+            if self.strict_allowlist and not self._is_allowed(argv):
+                overall = False
+                checks.append(
+                    GateCheckResult(
+                        command=command_label,
                         passed=False,
                         exit_code=126,
-                        output=f"blocked by gate allowlist: {command}",
+                        output=(
+                            "blocked by gate allowlist (strict mode); "
+                            "set AGENTFLOW_GATE_STRICT_ALLOWLIST=0 to opt out"
+                        ),
                     )
                 )
                 break
             try:
-                proc = subprocess.run(  # noqa: S602 - command source is project-controlled gate profile
-                    command,
-                    shell=True,
+                proc = subprocess.run(
+                    argv,
+                    shell=False,
                     capture_output=True,
                     text=True,
                     timeout=self.timeout_sec,
@@ -62,7 +83,7 @@ class GateEvaluator:
                 output = (proc.stdout or "") + (proc.stderr or "")
                 checks.append(
                     GateCheckResult(
-                        command=command,
+                        command=command_label,
                         passed=passed,
                         exit_code=proc.returncode,
                         output=output.strip(),
@@ -74,7 +95,7 @@ class GateEvaluator:
                 overall = False
                 checks.append(
                     GateCheckResult(
-                        command=command,
+                        command=command_label,
                         passed=False,
                         exit_code=124,
                         output=f"timeout after {self.timeout_sec}s: {exc}",
@@ -84,6 +105,54 @@ class GateEvaluator:
 
         return GateResult(passed=overall, checks=checks)
 
-    def _is_allowed(self, command: str) -> bool:
-        stripped = command.strip()
-        return any(stripped == p or stripped.startswith(f"{p} ") for p in self.allowed_prefixes)
+    def _parse_command(self, command: object) -> tuple[list[str], str] | None:
+        if isinstance(command, str):
+            stripped = command.strip()
+            if not stripped:
+                return None
+            argv = shlex.split(stripped)
+            if not argv:
+                return None
+            return argv, stripped
+
+        if isinstance(command, Mapping):
+            raw_command = command.get("command")
+            raw_args = command.get("args", [])
+            if not isinstance(raw_command, str) or not raw_command.strip():
+                return None
+            if raw_args is None:
+                args: list[str] = []
+            elif isinstance(raw_args, Sequence) and not isinstance(raw_args, (str, bytes)):
+                args = []
+                for arg in raw_args:
+                    if not isinstance(arg, str):
+                        return None
+                    args.append(arg)
+            else:
+                return None
+            normalized = {
+                "command": raw_command.strip(),
+                "args": args,
+            }
+            return [normalized["command"], *args], json.dumps(normalized, separators=(",", ":"))
+
+        return None
+
+    def _is_allowed(self, argv: Sequence[str]) -> bool:
+        if not self.allowed_prefixes:
+            return False
+
+        for prefix in self.allowed_prefixes:
+            prefix_argv = shlex.split(prefix)
+            if not prefix_argv:
+                continue
+            if list(argv[: len(prefix_argv)]) == prefix_argv:
+                return True
+        return False
+
+    def _command_label(self, command: object) -> str:
+        if isinstance(command, str):
+            return command.strip() or repr(command)
+        if isinstance(command, Mapping):
+            return json.dumps(command, sort_keys=True, default=str)
+        return repr(command)

--- a/src/agentflow/services/runner.py
+++ b/src/agentflow/services/runner.py
@@ -78,11 +78,16 @@ class Runner:
                     timeout_sec=timeout_sec,
                     cwd=self._resolve_workspace(context.repo_full_name),
                     allowed_prefixes=self._allowed_gate_prefixes(),
+                    strict_allowlist=self._gate_strict_allowlist(),
                 )
-                gate_result = evaluator.evaluate([str(c) for c in commands])
+                gate_result = evaluator.evaluate(commands)
                 gate_passed = gate_result.passed
                 gate_summary = "; ".join(
-                    [f"{c.command} => {'ok' if c.passed else 'fail'}" for c in gate_result.checks]
+                    [
+                        f"{c.command} => {'ok' if c.passed else 'fail'}"
+                        + (f" ({c.output})" if (not c.passed and c.output) else "")
+                        for c in gate_result.checks
+                    ]
                 )
                 self.store.append_run_step(
                     run_id,
@@ -142,3 +147,9 @@ class Runner:
             return None
         vals = [x.strip() for x in raw.split(",") if x.strip()]
         return vals or None
+
+    def _gate_strict_allowlist(self) -> bool:
+        raw = os.environ.get("AGENTFLOW_GATE_STRICT_ALLOWLIST")
+        if raw is None or not raw.strip():
+            return True
+        return raw.strip().lower() not in {"0", "false", "no", "off"}

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -22,7 +22,7 @@ class GateTests(unittest.TestCase):
         self.store.upsert_gate_profile(
             project="demo",
             required_checks=["unit", "lint"],
-            commands=["python3 -c \"print('ok')\""],
+            commands=[{"command": "python3", "args": ["-c", "print('ok')"]}],
             timeout_sec=120,
             retry_policy={"max_retries": 1},
             artifact_policy={"save_logs": True},
@@ -32,10 +32,11 @@ class GateTests(unittest.TestCase):
         self.assertIsNotNone(profile)
         assert profile is not None
         self.assertEqual(["unit", "lint"], profile["required_checks"])
+        self.assertEqual([{"command": "python3", "args": ["-c", "print('ok')"]}], profile["commands"])
         self.assertEqual(120, profile["timeout_sec"])
 
     def test_gate_evaluator_success_and_failure(self) -> None:
-        evaluator = GateEvaluator(timeout_sec=10)
+        evaluator = GateEvaluator(timeout_sec=10, strict_allowlist=False)
 
         success = evaluator.evaluate(["python3 -c \"print('ok')\""])
         self.assertTrue(success.passed)
@@ -43,11 +44,31 @@ class GateTests(unittest.TestCase):
         failure = evaluator.evaluate(["python3 -c \"import sys; sys.exit(2)\""])
         self.assertFalse(failure.passed)
 
-    def test_gate_allowlist_blocks_unlisted_command(self) -> None:
-        evaluator = GateEvaluator(timeout_sec=10, allowed_prefixes=["python3"])
+    def test_gate_evaluator_supports_structured_commands_without_shell(self) -> None:
+        evaluator = GateEvaluator(timeout_sec=10, strict_allowlist=False)
+        out = evaluator.evaluate(
+            [
+                {
+                    "command": "python3",
+                    "args": ["-c", "import sys; print(sys.argv[1])", "a&&b"],
+                }
+            ]
+        )
+        self.assertTrue(out.passed)
+        self.assertEqual("a&&b", out.checks[0].output)
+
+    def test_gate_allowlist_blocks_unlisted_command_by_default(self) -> None:
+        evaluator = GateEvaluator(timeout_sec=10)
         out = evaluator.evaluate(["echo hi"])
         self.assertFalse(out.passed)
         self.assertEqual(126, out.checks[0].exit_code)
+        self.assertIn("strict mode", out.checks[0].output)
+
+    def test_gate_allowlist_opt_out_mode_runs_unlisted_command(self) -> None:
+        evaluator = GateEvaluator(timeout_sec=10, strict_allowlist=False)
+        out = evaluator.evaluate(["echo hi"])
+        self.assertTrue(out.passed)
+        self.assertEqual("hi", out.checks[0].output)
 
 
 if __name__ == "__main__":

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from agentflow.adapters.registry import AdapterRegistry
 from agentflow.services.runner import Runner
@@ -47,7 +49,7 @@ class RunnerTests(unittest.TestCase):
         self.store.upsert_gate_profile(
             project="demo",
             required_checks=["unit"],
-            commands=["python3 -c \"import sys; sys.exit(3)\""],
+            commands=["python3 -c \"print('ok')\""],
             timeout_sec=30,
             retry_policy={"max_retries": 0},
             artifact_policy={},
@@ -69,6 +71,40 @@ class RunnerTests(unittest.TestCase):
         assert record.task is not None
         self.assertEqual("blocked", record.task.status)
         self.assertFalse(record.success)
+        self.assertIn("blocked by gate allowlist", record.message)
+
+    def test_run_once_allows_unlisted_gate_when_strict_allowlist_disabled(self) -> None:
+        with patch.dict(os.environ, {"AGENTFLOW_GATE_STRICT_ALLOWLIST": "0"}, clear=False):
+            self.store.upsert_gate_profile(
+                project="demo",
+                required_checks=["unit"],
+                commands=[
+                    {
+                        "command": "python3",
+                        "args": ["-c", "import sys; print(sys.argv[1])", "a&&b"],
+                    }
+                ],
+                timeout_sec=30,
+                retry_policy={"max_retries": 0},
+                artifact_policy={},
+            )
+            self.store.add_task(
+                project="demo",
+                title="fix crash on startup",
+                description=None,
+                priority=5,
+                impact=5,
+                effort=2,
+                source="github",
+                external_id="101",
+            )
+            runner = Runner(self.store, AdapterRegistry())
+            record = runner.run_once("demo", "mock", "codex-worker")
+
+            self.assertIsNotNone(record.task)
+            assert record.task is not None
+            self.assertTrue(record.success)
+            self.assertEqual("review", record.task.status)
 
     def test_run_once_execution_failure_preserves_gate_passed_state(self) -> None:
         task_id = self.store.add_task(


### PR DESCRIPTION
## Summary
- remove risky gate execution path using shell command strings
- support structured gate command templates: { "command": "...", "args": [...] }
- keep backward compatibility with legacy string commands
- enable strict allowlist mode by default with explicit opt-out env switch
- improve blocked-command feedback in gate summaries
- add gate and runner tests for strict-default, structured command, and opt-out behavior

## Validation
- PYTHONPATH=src python3 -m unittest tests.test_gates tests.test_runner
- PYTHONPATH=src python3 -m unittest discover -s tests -p 'test_*.py'