### PR TITLE
feat(db): bootstrap alembic migrations

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,37 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+path_separator = os
+version_path_separator = os
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = None
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+        render_as_batch=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+            render_as_batch=True,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,17 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}

--- a/migrations/versions/0001_bootstrap_schema.py
+++ b/migrations/versions/0001_bootstrap_schema.py
@@ -1,0 +1,220 @@
+"""bootstrap the agentflow schema
+
+Revision ID: 0001_bootstrap_schema
+Revises: None
+Create Date: 2026-04-01 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0001_bootstrap_schema"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(bind, table: str, column: str) -> bool:
+    rows = bind.exec_driver_sql(f"PRAGMA table_info({table})").fetchall()
+    return any(row[1] == column for row in rows)
+
+
+def _execute_many(bind, statements: list[str]) -> None:
+    for statement in statements:
+        bind.exec_driver_sql(statement)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    bind.exec_driver_sql("PRAGMA foreign_keys=ON")
+
+    _execute_many(
+        bind,
+        [
+            """
+            CREATE TABLE IF NOT EXISTS projects (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                repo_full_name TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+            """,
+            """
+            CREATE TABLE IF NOT EXISTS tasks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                project_id INTEGER NOT NULL,
+                title TEXT NOT NULL,
+                description TEXT,
+                status TEXT NOT NULL DEFAULT 'todo',
+                priority INTEGER NOT NULL DEFAULT 3 CHECK(priority BETWEEN 1 AND 5),
+                impact INTEGER NOT NULL DEFAULT 3 CHECK(impact BETWEEN 1 AND 5),
+                effort INTEGER NOT NULL DEFAULT 3 CHECK(effort BETWEEN 1 AND 5),
+                source TEXT,
+                external_id TEXT,
+                branch TEXT,
+                pr_url TEXT,
+                assigned_agent TEXT,
+                lease_until TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE
+            )
+            """,
+            """
+            CREATE TABLE IF NOT EXISTS status_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                task_id INTEGER NOT NULL,
+                from_status TEXT,
+                to_status TEXT NOT NULL,
+                note TEXT,
+                changed_at TEXT NOT NULL DEFAULT (datetime('now')),
+                FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE
+            )
+            """,
+            """
+            CREATE TABLE IF NOT EXISTS links (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                task_id INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                url TEXT NOT NULL,
+                FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE
+            )
+            """,
+            """
+            CREATE TABLE IF NOT EXISTS runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                task_id INTEGER NOT NULL,
+                project_id INTEGER NOT NULL,
+                trigger_type TEXT NOT NULL,
+                trigger_ref TEXT NOT NULL,
+                adapter TEXT NOT NULL,
+                agent_name TEXT NOT NULL,
+                workspace_ref TEXT,
+                status TEXT NOT NULL DEFAULT 'running',
+                gate_passed INTEGER NOT NULL DEFAULT 0,
+                result_summary TEXT,
+                error_code TEXT,
+                error_detail TEXT,
+                idempotency_key TEXT NOT NULL UNIQUE,
+                started_at TEXT NOT NULL DEFAULT (datetime('now')),
+                finished_at TEXT,
+                FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+                FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE
+            )
+            """,
+            """
+            CREATE TABLE IF NOT EXISTS run_steps (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                run_id INTEGER NOT NULL,
+                step_name TEXT NOT NULL,
+                status TEXT NOT NULL,
+                log_excerpt TEXT,
+                error_code TEXT,
+                started_at TEXT NOT NULL DEFAULT (datetime('now')),
+                ended_at TEXT NOT NULL DEFAULT (datetime('now')),
+                FOREIGN KEY(run_id) REFERENCES runs(id) ON DELETE CASCADE
+            )
+            """,
+            """
+            CREATE TABLE IF NOT EXISTS triggers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                project_id INTEGER NOT NULL,
+                trigger_type TEXT NOT NULL,
+                trigger_ref TEXT NOT NULL,
+                idempotency_key TEXT NOT NULL UNIQUE,
+                payload TEXT,
+                triggered_at TEXT NOT NULL DEFAULT (datetime('now')),
+                FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE
+            )
+            """,
+            """
+            CREATE TABLE IF NOT EXISTS gate_profiles (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                project_id INTEGER NOT NULL UNIQUE,
+                required_checks TEXT NOT NULL DEFAULT '[]',
+                commands TEXT NOT NULL DEFAULT '[]',
+                timeout_sec INTEGER NOT NULL DEFAULT 1800,
+                retry_policy TEXT NOT NULL DEFAULT '{}',
+                artifact_policy TEXT NOT NULL DEFAULT '{}',
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE
+            )
+            """,
+            """
+            CREATE TABLE IF NOT EXISTS events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                project_id INTEGER NOT NULL,
+                event TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE
+            )
+            """,
+        ],
+    )
+
+    if not _column_exists(bind, "tasks", "assigned_agent"):
+        bind.exec_driver_sql("ALTER TABLE tasks ADD COLUMN assigned_agent TEXT")
+    if not _column_exists(bind, "tasks", "lease_until"):
+        bind.exec_driver_sql("ALTER TABLE tasks ADD COLUMN lease_until TEXT")
+
+    bind.exec_driver_sql(
+        """
+        UPDATE tasks
+        SET status = CASE status
+            WHEN 'pending' THEN 'todo'
+            WHEN 'approved' THEN 'ready'
+            WHEN 'pr_ready' THEN 'review'
+            WHEN 'pr_open' THEN 'review'
+            WHEN 'merged' THEN 'done'
+            WHEN 'skipped' THEN 'dropped'
+            WHEN 'triaged' THEN 'ready'
+            ELSE status
+        END
+        """
+    )
+
+    _execute_many(
+        bind,
+        [
+            "CREATE INDEX IF NOT EXISTS idx_tasks_project_status ON tasks(project_id, status)",
+            "CREATE INDEX IF NOT EXISTS idx_tasks_project_priority ON tasks(project_id, priority DESC, impact DESC)",
+            "CREATE INDEX IF NOT EXISTS idx_tasks_lease ON tasks(lease_until, assigned_agent)",
+            "CREATE INDEX IF NOT EXISTS idx_runs_task_id ON runs(task_id)",
+            "CREATE INDEX IF NOT EXISTS idx_runs_project_id ON runs(project_id)",
+            "CREATE INDEX IF NOT EXISTS idx_run_steps_run_id ON run_steps(run_id)",
+            "CREATE INDEX IF NOT EXISTS idx_triggers_project_id ON triggers(project_id)",
+            "CREATE INDEX IF NOT EXISTS idx_events_project_id ON events(project_id, id)",
+        ],
+    )
+    bind.exec_driver_sql(
+        """
+        UPDATE status_history
+        SET from_status = CASE from_status
+            WHEN 'pending' THEN 'todo'
+            WHEN 'approved' THEN 'ready'
+            WHEN 'pr_ready' THEN 'review'
+            WHEN 'pr_open' THEN 'review'
+            WHEN 'merged' THEN 'done'
+            WHEN 'skipped' THEN 'dropped'
+            WHEN 'triaged' THEN 'ready'
+            ELSE from_status
+        END,
+        to_status = CASE to_status
+            WHEN 'pending' THEN 'todo'
+            WHEN 'approved' THEN 'ready'
+            WHEN 'pr_ready' THEN 'review'
+            WHEN 'pr_open' THEN 'review'
+            WHEN 'merged' THEN 'done'
+            WHEN 'skipped' THEN 'dropped'
+            WHEN 'triaged' THEN 'ready'
+            ELSE to_status
+        END
+        """
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("The bootstrap migration is intentionally forward-only.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "Tweakzx" }]
 license = { text = "MIT" }
-dependencies = []
+dependencies = ["alembic>=1.18.0"]
 
 [project.scripts]
 agentflow = "agentflow.cli:main"

--- a/src/agentflow/schema.py
+++ b/src/agentflow/schema.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import sqlite3
+from pathlib import Path
 
-SCHEMA_SQL = """
+BOOTSTRAP_REVISION = "0001_bootstrap_schema"
+
+LEGACY_SCHEMA_SQL = """
 PRAGMA foreign_keys = ON;
 
 CREATE TABLE IF NOT EXISTS projects (
@@ -114,16 +117,83 @@ CREATE TABLE IF NOT EXISTS events (
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     FOREIGN KEY(project_id) REFERENCES projects(id) ON DELETE CASCADE
 );
-
-CREATE INDEX IF NOT EXISTS idx_tasks_project_status ON tasks(project_id, status);
-CREATE INDEX IF NOT EXISTS idx_tasks_project_priority ON tasks(project_id, priority DESC, impact DESC);
-CREATE INDEX IF NOT EXISTS idx_tasks_lease ON tasks(lease_until, assigned_agent);
-CREATE INDEX IF NOT EXISTS idx_runs_task_id ON runs(task_id);
-CREATE INDEX IF NOT EXISTS idx_runs_project_id ON runs(project_id);
-CREATE INDEX IF NOT EXISTS idx_run_steps_run_id ON run_steps(run_id);
-CREATE INDEX IF NOT EXISTS idx_triggers_project_id ON triggers(project_id);
-CREATE INDEX IF NOT EXISTS idx_events_project_id ON events(project_id, id);
 """
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _sqlite_url(db_path: str) -> str:
+    resolved = Path(db_path).resolve().as_posix()
+    return f"sqlite:///{resolved}"
+
+
+def _bootstrap_legacy_schema(db_path: str) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(LEGACY_SCHEMA_SQL)
+        if not _column_exists(conn, "tasks", "assigned_agent"):
+            conn.execute("ALTER TABLE tasks ADD COLUMN assigned_agent TEXT")
+        if not _column_exists(conn, "tasks", "lease_until"):
+            conn.execute("ALTER TABLE tasks ADD COLUMN lease_until TEXT")
+        conn.executescript(
+            """
+            CREATE INDEX IF NOT EXISTS idx_tasks_project_status ON tasks(project_id, status);
+            CREATE INDEX IF NOT EXISTS idx_tasks_project_priority ON tasks(project_id, priority DESC, impact DESC);
+            CREATE INDEX IF NOT EXISTS idx_tasks_lease ON tasks(lease_until, assigned_agent);
+            CREATE INDEX IF NOT EXISTS idx_runs_task_id ON runs(task_id);
+            CREATE INDEX IF NOT EXISTS idx_runs_project_id ON runs(project_id);
+            CREATE INDEX IF NOT EXISTS idx_run_steps_run_id ON run_steps(run_id);
+            CREATE INDEX IF NOT EXISTS idx_triggers_project_id ON triggers(project_id);
+            CREATE INDEX IF NOT EXISTS idx_events_project_id ON events(project_id, id);
+            """
+        )
+        conn.execute(
+            """
+            UPDATE tasks
+            SET status = CASE status
+                WHEN 'pending' THEN 'todo'
+                WHEN 'approved' THEN 'ready'
+                WHEN 'pr_ready' THEN 'review'
+                WHEN 'pr_open' THEN 'review'
+                WHEN 'merged' THEN 'done'
+                WHEN 'skipped' THEN 'dropped'
+                WHEN 'triaged' THEN 'ready'
+                ELSE status
+            END
+            """
+        )
+        conn.execute(
+            """
+            UPDATE status_history
+            SET from_status = CASE from_status
+                WHEN 'pending' THEN 'todo'
+                WHEN 'approved' THEN 'ready'
+                WHEN 'pr_ready' THEN 'review'
+                WHEN 'pr_open' THEN 'review'
+                WHEN 'merged' THEN 'done'
+                WHEN 'skipped' THEN 'dropped'
+                WHEN 'triaged' THEN 'ready'
+                ELSE from_status
+            END,
+            to_status = CASE to_status
+                WHEN 'pending' THEN 'todo'
+                WHEN 'approved' THEN 'ready'
+                WHEN 'pr_ready' THEN 'review'
+                WHEN 'pr_open' THEN 'review'
+                WHEN 'merged' THEN 'done'
+                WHEN 'skipped' THEN 'dropped'
+                WHEN 'triaged' THEN 'ready'
+                ELSE to_status
+            END
+            """
+        )
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS alembic_version (version_num VARCHAR(32) NOT NULL)"
+        )
+        conn.execute("DELETE FROM alembic_version")
+        conn.execute("INSERT INTO alembic_version(version_num) VALUES(?)", (BOOTSTRAP_REVISION,))
+        conn.commit()
 
 
 def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
@@ -131,55 +201,16 @@ def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
     return any(row[1] == column for row in rows)
 
 
-def ensure_schema(conn: sqlite3.Connection) -> None:
-    conn.executescript(SCHEMA_SQL)
+def ensure_schema(db_path: str) -> None:
+    try:
+        from alembic import command
+        from alembic.config import Config
+    except ImportError:
+        _bootstrap_legacy_schema(db_path)
+        return
 
-    # Lightweight forward-only migrations for existing local DB files.
-    if not _column_exists(conn, "tasks", "assigned_agent"):
-        conn.execute("ALTER TABLE tasks ADD COLUMN assigned_agent TEXT")
-    if not _column_exists(conn, "tasks", "lease_until"):
-        conn.execute("ALTER TABLE tasks ADD COLUMN lease_until TEXT")
-
-    # Normalize legacy status names into the current lifecycle model.
-    conn.execute(
-        """
-        UPDATE tasks
-        SET status = CASE status
-            WHEN 'pending' THEN 'todo'
-            WHEN 'approved' THEN 'ready'
-            WHEN 'pr_ready' THEN 'review'
-            WHEN 'pr_open' THEN 'review'
-            WHEN 'merged' THEN 'done'
-            WHEN 'skipped' THEN 'dropped'
-            WHEN 'triaged' THEN 'ready'
-            ELSE status
-        END
-        """
-    )
-    conn.execute(
-        """
-        UPDATE status_history
-        SET from_status = CASE from_status
-            WHEN 'pending' THEN 'todo'
-            WHEN 'approved' THEN 'ready'
-            WHEN 'pr_ready' THEN 'review'
-            WHEN 'pr_open' THEN 'review'
-            WHEN 'merged' THEN 'done'
-            WHEN 'skipped' THEN 'dropped'
-            WHEN 'triaged' THEN 'ready'
-            ELSE from_status
-        END,
-        to_status = CASE to_status
-            WHEN 'pending' THEN 'todo'
-            WHEN 'approved' THEN 'ready'
-            WHEN 'pr_ready' THEN 'review'
-            WHEN 'pr_open' THEN 'review'
-            WHEN 'merged' THEN 'done'
-            WHEN 'skipped' THEN 'dropped'
-            WHEN 'triaged' THEN 'ready'
-            ELSE to_status
-        END
-        """
-    )
-
-    conn.commit()
+    root = _repo_root()
+    config = Config(str(root / "alembic.ini"))
+    config.set_main_option("script_location", str(root / "migrations"))
+    config.set_main_option("sqlalchemy.url", _sqlite_url(db_path))
+    command.upgrade(config, "head")

--- a/src/agentflow/store.py
+++ b/src/agentflow/store.py
@@ -67,15 +67,15 @@ class Store:
         self._schema_lock = threading.Lock()
 
     def connect(self) -> sqlite3.Connection:
+        if not self._schema_ready:
+            with self._schema_lock:
+                if not self._schema_ready:
+                    ensure_schema(self.db_path)
+                    self._schema_ready = True
         conn = sqlite3.connect(self.db_path, factory=_ManagedConnection)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA busy_timeout=5000")
-        if not self._schema_ready:
-            with self._schema_lock:
-                if not self._schema_ready:
-                    ensure_schema(conn)
-                    self._schema_ready = True
         return conn
 
     def create_project(self, name: str, repo_full_name: str | None) -> None:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -322,6 +322,120 @@ class StoreTests(unittest.TestCase):
         claimed = legacy_store.claim_next_task("demo", "worker-a")
         self.assertIsNotNone(claimed)
 
+    def test_legacy_database_bootstraps_via_alembic(self) -> None:
+        db_path = Path(self.tempdir.name) / "legacy-bootstrap.db"
+        with sqlite3.connect(db_path) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE projects (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL UNIQUE,
+                    repo_full_name TEXT,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+                CREATE TABLE tasks (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    project_id INTEGER NOT NULL,
+                    title TEXT NOT NULL,
+                    description TEXT,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    priority INTEGER NOT NULL DEFAULT 3 CHECK(priority BETWEEN 1 AND 5),
+                    impact INTEGER NOT NULL DEFAULT 3 CHECK(impact BETWEEN 1 AND 5),
+                    effort INTEGER NOT NULL DEFAULT 3 CHECK(effort BETWEEN 1 AND 5),
+                    source TEXT,
+                    external_id TEXT,
+                    branch TEXT,
+                    pr_url TEXT,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+                CREATE TABLE status_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    task_id INTEGER NOT NULL,
+                    from_status TEXT,
+                    to_status TEXT NOT NULL,
+                    note TEXT,
+                    changed_at TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+                INSERT INTO projects(name, repo_full_name) VALUES('demo', 'example/demo');
+                INSERT INTO tasks(project_id, title, description, status, priority, impact, effort, source, external_id)
+                VALUES(1, 'legacy-task', NULL, 'pending', 3, 3, 2, NULL, NULL);
+                INSERT INTO status_history(task_id, from_status, to_status, note)
+                VALUES(1, 'pending', 'approved', 'legacy state');
+                """
+            )
+            conn.commit()
+
+        store = Store(str(db_path))
+        with store.connect() as conn:
+            task = conn.execute("SELECT status, assigned_agent, lease_until FROM tasks WHERE id = 1").fetchone()
+            assert task is not None
+            self.assertEqual("todo", task["status"])
+            self.assertIsNone(task["assigned_agent"])
+            self.assertIsNone(task["lease_until"])
+            history = conn.execute(
+                "SELECT from_status, to_status FROM status_history WHERE task_id = 1 ORDER BY id ASC"
+            ).fetchone()
+            assert history is not None
+            self.assertEqual(("todo", "ready"), (history["from_status"], history["to_status"]))
+            version = conn.execute("SELECT version_num FROM alembic_version").fetchone()
+            assert version is not None
+            self.assertEqual("0001_bootstrap_schema", version["version_num"])
+
+    def test_versioned_database_startup_does_not_rewrite_rows(self) -> None:
+        db_path = Path(self.tempdir.name) / "versioned-no-rewrite.db"
+        with sqlite3.connect(db_path) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE projects (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL UNIQUE,
+                    repo_full_name TEXT,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+                CREATE TABLE tasks (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    project_id INTEGER NOT NULL,
+                    title TEXT NOT NULL,
+                    description TEXT,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    priority INTEGER NOT NULL DEFAULT 3 CHECK(priority BETWEEN 1 AND 5),
+                    impact INTEGER NOT NULL DEFAULT 3 CHECK(impact BETWEEN 1 AND 5),
+                    effort INTEGER NOT NULL DEFAULT 3 CHECK(effort BETWEEN 1 AND 5),
+                    source TEXT,
+                    external_id TEXT,
+                    branch TEXT,
+                    pr_url TEXT,
+                    assigned_agent TEXT,
+                    lease_until TEXT,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+                CREATE TABLE status_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    task_id INTEGER NOT NULL,
+                    from_status TEXT,
+                    to_status TEXT NOT NULL,
+                    note TEXT,
+                    changed_at TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+                CREATE TABLE alembic_version (
+                    version_num VARCHAR(32) NOT NULL
+                );
+                INSERT INTO alembic_version(version_num) VALUES('0001_bootstrap_schema');
+                INSERT INTO projects(name, repo_full_name) VALUES('demo', 'example/demo');
+                INSERT INTO tasks(project_id, title, description, status, priority, impact, effort, source, external_id)
+                VALUES(1, 'legacy-task', NULL, 'pending', 3, 3, 2, NULL, NULL);
+                """
+            )
+            conn.commit()
+
+        store = Store(str(db_path))
+        with store.connect() as conn:
+            task = conn.execute("SELECT status FROM tasks WHERE id = 1").fetchone()
+            assert task is not None
+            self.assertEqual("pending", task["status"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- introduce Alembic as primary migration framework
- add migration scaffolding (alembic.ini, migrations/env.py, template)
- add initial schema migration and move legacy status normalization into migration flow
- remove startup-time unconditional mass rewrites from normal runtime path
- keep temporary compatibility fallback for pre-Alembic local DBs
- add store/schema tests for migration bootstrap behavior

## Validation
- PYTHONPATH=src python3 -m unittest tests.test_store