### PR TITLE
Add Jira-lite issue semantics for agent task boards

### DIFF
--- a/src/agentflow/cli.py
+++ b/src/agentflow/cli.py
@@ -34,9 +34,14 @@ def _parser() -> argparse.ArgumentParser:
     p_add.add_argument("--project", required=True)
     p_add.add_argument("--title", required=True)
     p_add.add_argument("--description")
+    p_add.add_argument("--issue-type", default="task")
     p_add.add_argument("--priority", type=int, default=3)
     p_add.add_argument("--impact", type=int, default=3)
     p_add.add_argument("--effort", type=int, default=3)
+    p_add.add_argument("--success-criteria")
+    p_add.add_argument("--risk-level", default="medium")
+    p_add.add_argument("--reporter")
+    p_add.add_argument("--environment")
     p_add.add_argument("--source")
     p_add.add_argument("--external-id")
 
@@ -165,13 +170,14 @@ def _print_tasks(tasks) -> None:
     if not tasks:
         print("(no tasks)")
         return
-    print("id  project  status       pri imp eff score  agent         lease_until           title")
-    print("--  -------  -----------  --- --- --- -----  ------------  -------------------  -----")
+    print("id  project  type      status                 risk      pri imp eff score  agent         lease_until           title")
+    print("--  -------  --------  ---------------------  --------  --- --- --- -----  ------------  -------------------  -----")
     for t in tasks:
         agent = t.assigned_agent or "-"
         lease = t.lease_until or "-"
         print(
-            f"{t.id:<3} {t.project:<8} {t.status:<11}  {t.priority:<3} {t.impact:<3} {t.effort:<3} {t.score:<5.1f}  {agent:<12}  {lease:<19}  {t.title}"
+            f"{t.id:<3} {t.project:<8} {t.issue_type:<8}  {t.status:<21}  {t.risk_level:<8}  "
+            f"{t.priority:<3} {t.impact:<3} {t.effort:<3} {t.score:<5.1f}  {agent:<12}  {lease:<19}  {t.title}"
         )
 
 
@@ -206,9 +212,14 @@ def main() -> None:
             project=args.project,
             title=args.title,
             description=args.description,
+            issue_type=args.issue_type,
             priority=args.priority,
             impact=args.impact,
             effort=args.effort,
+            success_criteria=args.success_criteria,
+            risk_level=args.risk_level,
+            reporter=args.reporter,
+            environment=args.environment,
             source=args.source,
             external_id=args.external_id,
         )

--- a/src/agentflow/console.py
+++ b/src/agentflow/console.py
@@ -724,10 +724,12 @@ def _flow_stage_for_status(status: str) -> str:
         "todo": "todo",
         "ready": "ready",
         "in_progress": "in_progress",
+        "waiting_for_approval": "waiting_for_approval",
         "review": "review",
         "done": "done",
         "dropped": "dropped",
         "blocked": "blocked",
+        "failed": "failed",
     }
     return mapping.get(status, "other")
 
@@ -881,12 +883,19 @@ def _create_task_from_payload(store: Store, payload: dict[str, Any]) -> dict[str
             project=project,
             title=title,
             description=str(payload.get("description")) if payload.get("description") is not None else None,
+            issue_type=str(payload.get("issue_type") or payload.get("type") or "task"),
             priority=priority,
             impact=impact,
             effort=effort,
+            success_criteria=str(payload.get("success_criteria")) if payload.get("success_criteria") is not None else None,
+            risk_level=str(payload.get("risk_level") or "medium"),
+            reporter=str(payload.get("reporter")) if payload.get("reporter") is not None else None,
+            environment=str(payload.get("environment")) if payload.get("environment") is not None else None,
             source=str(payload.get("source")) if payload.get("source") is not None else None,
             external_id=str(payload.get("external_id")) if payload.get("external_id") is not None else None,
         )
+        for raw_blocker in payload.get("blocked_by", []) if isinstance(payload.get("blocked_by"), list) else []:
+            store.add_task_dependency(task_id, int(raw_blocker), "depends_on")
     except ValueError as exc:
         return {"ok": False, "error": str(exc)}
     task = store.get_task(task_id)
@@ -897,9 +906,11 @@ def _validate_manual_transition(from_status: str, to_status: str) -> str | None:
     allowed = {
         "todo": {"ready", "blocked", "dropped"},
         "ready": {"todo", "in_progress", "review", "blocked", "dropped"},
-        "in_progress": {"ready", "review", "blocked"},
+        "in_progress": {"ready", "waiting_for_approval", "review", "blocked", "failed"},
+        "waiting_for_approval": {"ready", "in_progress", "review", "blocked", "failed"},
         "review": {"ready", "done", "blocked"},
-        "blocked": {"todo", "ready", "in_progress", "dropped"},
+        "blocked": {"todo", "ready", "in_progress", "waiting_for_approval", "dropped"},
+        "failed": {"ready", "blocked", "dropped"},
         "done": set(),
         "dropped": set(),
     }
@@ -1139,6 +1150,7 @@ def _build_handler(
                         run["steps"] = [_row_to_dict(s) for s in store.list_run_steps(int(run["id"]))]
                     timeline = store.list_task_timeline(task_id, limit=50)
                     history = [_row_to_dict(h) for h in store.list_status_history(task_id)]
+                    dependencies = [_row_to_dict(d) for d in store.list_task_dependencies(task_id)]
                     task_dict = _task_to_dict(task)
                     repo = store.get_project_repo(task.project)
                     latest_run = recent_runs[0] if recent_runs else None
@@ -1156,6 +1168,7 @@ def _build_handler(
                             "recent_runs": recent_runs,
                             "timeline": timeline,
                             "history": history,
+                            "dependencies": dependencies,
                             "links": links,
                             "pr_summary": pr_summary,
                             "derived_summary": derive_task_summary(timeline),

--- a/src/agentflow/reports.py
+++ b/src/agentflow/reports.py
@@ -5,6 +5,18 @@ from pathlib import Path
 
 from .store import Store
 
+BOARD_STATUSES = [
+    "todo",
+    "ready",
+    "in_progress",
+    "waiting_for_approval",
+    "review",
+    "blocked",
+    "failed",
+    "done",
+    "dropped",
+]
+
 
 def export_markdown(store: Store, out_dir: str, project: str | None = None) -> list[str]:
     Path(out_dir).mkdir(parents=True, exist_ok=True)
@@ -23,7 +35,7 @@ def export_markdown(store: Store, out_dir: str, project: str | None = None) -> l
 
         out_path = Path(out_dir) / f"{project_name}-board.md"
         lines = [f"# {project_name} task board", ""]
-        for status in ["todo", "ready", "in_progress", "review", "done", "blocked", "dropped"]:
+        for status in BOARD_STATUSES:
             lines.append(f"## {status}")
             group = status_groups.get(status, [])
             if not group:
@@ -31,7 +43,7 @@ def export_markdown(store: Store, out_dir: str, project: str | None = None) -> l
             else:
                 for t in group:
                     ext = f" ({t.source}:{t.external_id})" if t.source and t.external_id else ""
-                    lines.append(f"- [{t.id}] {t.title}{ext}")
+                    lines.append(f"- [{t.id}] {t.issue_type} {t.title} ({t.risk_level} risk){ext}")
             lines.append("")
 
         out_path.write_text("\n".join(lines), encoding="utf-8")
@@ -41,7 +53,7 @@ def export_markdown(store: Store, out_dir: str, project: str | None = None) -> l
 
 
 def build_dashboard_html(store: Store) -> str:
-    statuses = ["todo", "ready", "in_progress", "review", "done", "blocked", "dropped"]
+    statuses = BOARD_STATUSES
     rows = []
     for project in store.projects():
         counts = store.status_counts(project)

--- a/src/agentflow/schema.py
+++ b/src/agentflow/schema.py
@@ -17,10 +17,15 @@ CREATE TABLE IF NOT EXISTS tasks (
     project_id INTEGER NOT NULL,
     title TEXT NOT NULL,
     description TEXT,
+    issue_type TEXT NOT NULL DEFAULT 'task',
     status TEXT NOT NULL DEFAULT 'todo',
     priority INTEGER NOT NULL DEFAULT 3 CHECK(priority BETWEEN 1 AND 5),
     impact INTEGER NOT NULL DEFAULT 3 CHECK(impact BETWEEN 1 AND 5),
     effort INTEGER NOT NULL DEFAULT 3 CHECK(effort BETWEEN 1 AND 5),
+    success_criteria TEXT,
+    risk_level TEXT NOT NULL DEFAULT 'medium',
+    reporter TEXT,
+    environment TEXT,
     source TEXT,
     external_id TEXT,
     branch TEXT,
@@ -48,6 +53,17 @@ CREATE TABLE IF NOT EXISTS links (
     kind TEXT NOT NULL,
     url TEXT NOT NULL,
     FOREIGN KEY(task_id) REFERENCES tasks(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS task_dependencies (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    blocked_task_id INTEGER NOT NULL,
+    blocking_task_id INTEGER NOT NULL,
+    kind TEXT NOT NULL DEFAULT 'blocks',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(blocked_task_id, blocking_task_id, kind),
+    FOREIGN KEY(blocked_task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+    FOREIGN KEY(blocking_task_id) REFERENCES tasks(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS runs (
@@ -172,10 +188,24 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
     conn.executescript(SCHEMA_SQL)
 
     # Lightweight forward-only migrations for existing local DB files.
+    if not _column_exists(conn, "tasks", "issue_type"):
+        conn.execute("ALTER TABLE tasks ADD COLUMN issue_type TEXT NOT NULL DEFAULT 'task'")
+    if not _column_exists(conn, "tasks", "success_criteria"):
+        conn.execute("ALTER TABLE tasks ADD COLUMN success_criteria TEXT")
+    if not _column_exists(conn, "tasks", "risk_level"):
+        conn.execute("ALTER TABLE tasks ADD COLUMN risk_level TEXT NOT NULL DEFAULT 'medium'")
+    if not _column_exists(conn, "tasks", "reporter"):
+        conn.execute("ALTER TABLE tasks ADD COLUMN reporter TEXT")
+    if not _column_exists(conn, "tasks", "environment"):
+        conn.execute("ALTER TABLE tasks ADD COLUMN environment TEXT")
     if not _column_exists(conn, "tasks", "assigned_agent"):
         conn.execute("ALTER TABLE tasks ADD COLUMN assigned_agent TEXT")
     if not _column_exists(conn, "tasks", "lease_until"):
         conn.execute("ALTER TABLE tasks ADD COLUMN lease_until TEXT")
+
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_issue_type ON tasks(project_id, issue_type)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_task_dependencies_blocked ON task_dependencies(blocked_task_id)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_task_dependencies_blocking ON task_dependencies(blocking_task_id)")
 
     # Normalize legacy status names into the current lifecycle model.
     conn.execute(

--- a/src/agentflow/store.py
+++ b/src/agentflow/store.py
@@ -13,20 +13,27 @@ STATUSES = {
     "todo",
     "ready",
     "in_progress",
+    "waiting_for_approval",
     "review",
     "done",
     "dropped",
     "blocked",
+    "failed",
 }
 
-ACTIVE_STATUSES = {"todo", "ready", "in_progress", "review", "blocked"}
+ISSUE_TYPES = {"task", "bug", "story", "sub_task", "incident", "research"}
+RISK_LEVELS = {"low", "medium", "high", "critical"}
+
+ACTIVE_STATUSES = {"todo", "ready", "in_progress", "waiting_for_approval", "review", "blocked", "failed"}
 CLAIMABLE_STATUSES = {"todo", "ready"}
 ALLOWED_TRANSITIONS = {
     "todo": {"ready", "blocked", "dropped"},
     "ready": {"todo", "in_progress", "review", "blocked", "dropped"},
-    "in_progress": {"ready", "review", "blocked"},
+    "in_progress": {"ready", "waiting_for_approval", "review", "blocked", "failed"},
+    "waiting_for_approval": {"ready", "in_progress", "review", "blocked", "failed"},
     "review": {"ready", "done", "blocked"},
-    "blocked": {"todo", "ready", "in_progress", "dropped"},
+    "blocked": {"todo", "ready", "in_progress", "waiting_for_approval", "dropped"},
+    "failed": {"ready", "blocked", "dropped"},
     "done": set(),
     "dropped": set(),
 }
@@ -43,10 +50,15 @@ class Task:
     project: str
     title: str
     description: str | None
+    issue_type: str
     status: str
     priority: int
     impact: int
     effort: int
+    success_criteria: str | None
+    risk_level: str
+    reporter: str | None
+    environment: str | None
     source: str | None
     external_id: str | None
     pr_url: str | None
@@ -110,18 +122,42 @@ class Store:
         effort: int,
         source: str | None,
         external_id: str | None,
+        issue_type: str = "task",
+        success_criteria: str | None = None,
+        risk_level: str = "medium",
+        reporter: str | None = None,
+        environment: str | None = None,
     ) -> int:
         self._validate_score("priority", priority)
         self._validate_score("impact", impact)
         self._validate_score("effort", effort)
+        issue_type = self._normalize_issue_type(issue_type)
+        risk_level = self._normalize_risk_level(risk_level)
         with self.connect() as conn:
             project_id = self._project_id(conn, project)
             cur = conn.execute(
                 """
-                INSERT INTO tasks(project_id, title, description, status, priority, impact, effort, source, external_id)
-                VALUES(?, ?, ?, 'todo', ?, ?, ?, ?, ?)
+                INSERT INTO tasks(
+                    project_id, title, description, issue_type, status, priority, impact, effort,
+                    success_criteria, risk_level, reporter, environment, source, external_id
+                )
+                VALUES(?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                (project_id, title, description, priority, impact, effort, source, external_id),
+                (
+                    project_id,
+                    title,
+                    description,
+                    issue_type,
+                    priority,
+                    impact,
+                    effort,
+                    success_criteria,
+                    risk_level,
+                    reporter,
+                    environment,
+                    source,
+                    external_id,
+                ),
             )
             task_id = int(cur.lastrowid)
             conn.execute(
@@ -133,6 +169,20 @@ class Store:
     def _validate_score(self, name: str, value: int) -> None:
         if not isinstance(value, int) or value < 1 or value > 5:
             raise ValueError(f"{name} must be an integer between 1 and 5")
+
+    def _normalize_issue_type(self, issue_type: str) -> str:
+        normalized = issue_type.strip().lower().replace("-", "_")
+        if normalized not in ISSUE_TYPES:
+            valid = ", ".join(sorted(ISSUE_TYPES))
+            raise ValueError(f"Invalid issue_type: {issue_type}. Valid issue types: {valid}")
+        return normalized
+
+    def _normalize_risk_level(self, risk_level: str) -> str:
+        normalized = risk_level.strip().lower()
+        if normalized not in RISK_LEVELS:
+            valid = ", ".join(sorted(RISK_LEVELS))
+            raise ValueError(f"Invalid risk_level: {risk_level}. Valid risk levels: {valid}")
+        return normalized
 
     def create_run(
         self,
@@ -767,8 +817,10 @@ class Store:
 
     def _base_task_sql(self) -> str:
         return """
-            SELECT t.id, p.name AS project, t.title, t.description, t.status, t.priority, t.impact, t.effort,
-                   t.source, t.external_id, t.pr_url, t.assigned_agent, t.lease_until
+            SELECT t.id, p.name AS project, t.title, t.description, t.issue_type, t.status,
+                   t.priority, t.impact, t.effort, t.success_criteria, t.risk_level,
+                   t.reporter, t.environment, t.source, t.external_id, t.pr_url,
+                   t.assigned_agent, t.lease_until
             FROM tasks t
             JOIN projects p ON p.id = t.project_id
         """
@@ -1070,8 +1122,8 @@ class Store:
                 """
                 UPDATE tasks
                 SET status = ?,
-                    assigned_agent = CASE WHEN ? IN ('done', 'dropped', 'blocked', 'ready', 'todo', 'review') THEN NULL ELSE assigned_agent END,
-                    lease_until = CASE WHEN ? IN ('done', 'dropped', 'blocked', 'ready', 'todo', 'review') THEN NULL ELSE lease_until END,
+                    assigned_agent = CASE WHEN ? IN ('done', 'dropped', 'blocked', 'ready', 'todo', 'review', 'waiting_for_approval', 'failed') THEN NULL ELSE assigned_agent END,
+                    lease_until = CASE WHEN ? IN ('done', 'dropped', 'blocked', 'ready', 'todo', 'review', 'waiting_for_approval', 'failed') THEN NULL ELSE lease_until END,
                     updated_at = datetime('now')
                 WHERE id = ?
                 """,
@@ -1089,6 +1141,54 @@ class Store:
                 status_to=to_status,
                 ledger_event=ledger_event,
             )
+
+    def add_task_dependency(self, blocked_task_id: int, blocking_task_id: int, kind: str = "blocks") -> int:
+        kind = kind.strip().lower().replace("-", "_") or "blocks"
+        if kind not in {"blocks", "depends_on"}:
+            raise ValueError("dependency kind must be blocks or depends_on")
+        with self.connect() as conn:
+            blocked = conn.execute("SELECT project_id FROM tasks WHERE id = ?", (blocked_task_id,)).fetchone()
+            blocking = conn.execute("SELECT project_id FROM tasks WHERE id = ?", (blocking_task_id,)).fetchone()
+            if blocked is None:
+                raise ValueError(f"Task {blocked_task_id} not found")
+            if blocking is None:
+                raise ValueError(f"Task {blocking_task_id} not found")
+            if int(blocked["project_id"]) != int(blocking["project_id"]):
+                raise ValueError("Task dependencies must stay within one project")
+            cur = conn.execute(
+                """
+                INSERT OR IGNORE INTO task_dependencies(blocked_task_id, blocking_task_id, kind)
+                VALUES(?, ?, ?)
+                """,
+                (blocked_task_id, blocking_task_id, kind),
+            )
+            row = conn.execute(
+                """
+                SELECT id FROM task_dependencies
+                WHERE blocked_task_id = ? AND blocking_task_id = ? AND kind = ?
+                """,
+                (blocked_task_id, blocking_task_id, kind),
+            ).fetchone()
+            if row is None:
+                raise ValueError("Task dependency insert failed")
+            return int(row["id"])
+
+    def list_task_dependencies(self, task_id: int) -> list[sqlite3.Row]:
+        with self.connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT td.id, td.blocked_task_id, blocked.title AS blocked_title,
+                       td.blocking_task_id, blocking.title AS blocking_title,
+                       td.kind, td.created_at
+                FROM task_dependencies td
+                JOIN tasks blocked ON blocked.id = td.blocked_task_id
+                JOIN tasks blocking ON blocking.id = td.blocking_task_id
+                WHERE td.blocked_task_id = ? OR td.blocking_task_id = ?
+                ORDER BY td.id ASC
+                """,
+                (task_id, task_id),
+            ).fetchall()
+            return list(rows)
 
     def _validate_transition(self, from_status: str, to_status: str) -> None:
         from_status = self._normalize_status(from_status)

--- a/src/agentflow/web/static/console.css
+++ b/src/agentflow/web/static/console.css
@@ -115,19 +115,23 @@ input, select {
 .stage-todo { background: #e8f0ff; color: var(--c-todo); border-color: #bfd4ff; }
 .stage-ready { background: #efe9ff; color: var(--c-ready); border-color: #d8c8ff; }
 .stage-executing, .stage-in_progress { background: #e4f7f4; color: var(--c-executing); border-color: #b5ece4; }
+.stage-waiting_for_approval { background: #fff7d6; color: #a16207; border-color: #fde68a; }
 .stage-review { background: #fff4e6; color: var(--c-review); border-color: #ffdcb1; }
 .stage-done { background: #e7f8ea; color: var(--c-done); border-color: #bdeec7; }
 .stage-blocked { background: #ffe8e8; color: var(--c-blocked); border-color: #ffc2c2; }
-.status-todo, .status-ready, .status-in-progress, .status-review, .status-done, .status-dropped, .status-blocked {
+.stage-failed { background: #ffe8e8; color: var(--c-blocked); border-color: #ffc2c2; }
+.status-todo, .status-ready, .status-in-progress, .status-waiting-for-approval, .status-review, .status-done, .status-dropped, .status-blocked, .status-failed {
   font-weight: 600;
 }
 .status-todo { color: var(--c-todo); }
 .status-ready { color: var(--c-ready); }
 .status-in-progress { color: var(--c-executing); }
+.status-waiting-for-approval { color: #a16207; }
 .status-review { color: var(--c-review); }
 .status-done { color: var(--c-done); }
 .status-dropped { color: #64748b; }
 .status-blocked { color: var(--c-blocked); }
+.status-failed { color: var(--c-blocked); }
 
 /* ── Task Detail Redesign ── */
 
@@ -219,6 +223,9 @@ input, select {
 .tag-impact-med  { background: #fff4e6; color: var(--c-review); border-color: #ffdcb1; }
 .tag-impact-low  { background: #e7f8ea; color: var(--c-done); border-color: #bdeec7; }
 .tag-effort { background: #e8f0ff; color: var(--c-todo); border-color: #bfd4ff; }
+.tag-risk-critical, .tag-risk-high { background: #ffe8e8; color: var(--c-blocked); border-color: #ffc2c2; }
+.tag-risk-medium { background: #fff4e6; color: var(--c-review); border-color: #ffdcb1; }
+.tag-risk-low { background: #e7f8ea; color: var(--c-done); border-color: #bdeec7; }
 
 /* Description */
 .detail-description {

--- a/src/agentflow/web/static/console.js
+++ b/src/agentflow/web/static/console.js
@@ -15,8 +15,10 @@
         todo: true,
         ready: true,
         in_progress: true,
+        waiting_for_approval: true,
         review: true,
         blocked: true,
+        failed: true,
         done: false,
         dropped: false,
       },
@@ -40,15 +42,17 @@
       if (status === 'todo') return 'todo';
       if (status === 'ready') return 'ready';
       if (status === 'in_progress') return 'in_progress';
+      if (status === 'waiting_for_approval') return 'waiting_for_approval';
       if (status === 'review') return 'review';
       if (status === 'done') return 'done';
       if (status === 'dropped') return 'dropped';
       if (status === 'blocked') return 'blocked';
+      if (status === 'failed') return 'failed';
       return 'other';
     }
 
     function statusOrder() {
-      return ['todo', 'ready', 'in_progress', 'review', 'blocked', 'done', 'dropped'];
+      return ['todo', 'ready', 'in_progress', 'waiting_for_approval', 'review', 'blocked', 'failed', 'done', 'dropped'];
     }
 
     async function loadProjects() {
@@ -125,6 +129,8 @@
             <div class="task ${state.selectedTask && state.selectedTask.id === t.id ? 'active' : ''}" onclick="openTask(${t.id})">
               <div class="task-title">#${t.id} ${t.title}</div>
               <div class="meta">
+                <span>${t.issue_type || 'task'}</span>
+                <span>${t.risk_level || 'medium'} risk</span>
                 <span>p${t.priority}/i${t.impact}/e${t.effort}</span>
                 <span>${t.assigned_agent || '-'}</span>
               </div>
@@ -190,6 +196,7 @@
       const prUrl = links.pr_url || '';
       const repo = links.repo || '';
       const prCandidates = links.pr_candidates || [];
+      const dependencies = data.dependencies || [];
       const allRuns = (data.recent_runs || data.runs || []).slice(0, 5);
       const timelineRows = (data.timeline || []).slice(0, 20);
       const recommendedActions = Array.isArray(derived.recommended_actions) ? derived.recommended_actions : [];
@@ -204,6 +211,8 @@
       let summaryText = '';
       let needsAttention = false;
       if (stage === 'blocked') { summaryText = 'Task is blocked and needs your attention.'; needsAttention = true; }
+      else if (stage === 'waiting_for_approval') { summaryText = 'Agent is waiting for human approval before continuing.'; needsAttention = true; }
+      else if (stage === 'failed') { summaryText = 'Last agent attempt failed. Review the run details or retry.'; needsAttention = true; }
       else if (stage === 'review') { summaryText = derived.latest_risk ? 'Agent completed but flagged a risk. Please review.' : 'Agent completed work. Please review.'; }
       else if (stage === 'in_progress') { summaryText = `Agent is working on this task.${t.assigned_agent ? ' (' + t.assigned_agent + ')' : ''}`; }
       else if (stage === 'ready') { summaryText = 'Ready to be picked up by an agent.'; }
@@ -224,6 +233,17 @@
           <button onclick="runTask(${t.id})">Retry</button>
           <button class="btn-unblock" onclick="moveTask(${t.id},'ready','Unblocked by human',true)">Unblock</button>
           <button class="btn-reject" onclick="moveTask(${t.id},'dropped','Dropped by human',true)">Drop</button>
+        `;
+      } else if (stage === 'waiting_for_approval') {
+        actionButtons = `
+          <button class="btn-approve" onclick="moveTask(${t.id},'in_progress','Approved via console',false)">Approve</button>
+          <button class="btn-reject" onclick="moveTask(${t.id},'blocked','Approval denied via console',false)">Deny</button>
+        `;
+      } else if (stage === 'failed') {
+        actionButtons = `
+          <button onclick="moveTask(${t.id},'ready','Retry after failure',false)">Retry</button>
+          <button class="btn-block" onclick="moveTask(${t.id},'blocked','Failure needs triage',false)">Triage</button>
+          <button class="btn-reject" onclick="moveTask(${t.id},'dropped','Dropped after failure',false)">Drop</button>
         `;
       } else if (stage === 'in_progress') {
         actionButtons = `
@@ -248,7 +268,10 @@
           </div>
           <div class="detail-summary ${needsAttention ? 'summary-alert' : ''}">${summaryText}</div>
           ${t.description ? `<div class="detail-description">${t.description}</div>` : ''}
+          ${t.success_criteria ? `<div class="detail-description"><strong>Success criteria:</strong> ${t.success_criteria}</div>` : ''}
           <div class="detail-tag-row">
+            <span class="tag-badge">${(t.issue_type || 'task').replace('_',' ')}</span>
+            <span class="tag-badge tag-risk-${t.risk_level || 'medium'}">Risk: ${t.risk_level || 'medium'}</span>
             <span class="tag-badge tag-priority-${t.priority >= 4 ? 'high' : t.priority >= 3 ? 'med' : 'low'}">${priorityLabel(t.priority)}</span>
             <span class="tag-badge tag-impact-${t.impact >= 4 ? 'high' : t.impact >= 3 ? 'med' : 'low'}">Impact: ${impactLabel(t.impact)}</span>
             <span class="tag-badge tag-effort">Effort: ${effortLabel(t.effort)}</span>
@@ -256,6 +279,8 @@
           <div class="detail-meta-row">
             <span class="meta-chip"><span class="meta-chip-label">Source</span> ${t.source || '-'}</span>
             ${t.external_id ? `<span class="meta-chip">${t.external_id}</span>` : ''}
+            ${t.reporter ? `<span class="meta-chip"><span class="meta-chip-label">Reporter</span> ${t.reporter}</span>` : ''}
+            ${t.environment ? `<span class="meta-chip"><span class="meta-chip-label">Environment</span> ${t.environment}</span>` : ''}
             <span class="meta-chip"><span class="meta-chip-label">Agent</span> ${t.assigned_agent || '-'}</span>
           </div>
           ${(repo || issueUrl || prUrl || prCandidates.length) ? `
@@ -305,10 +330,12 @@
                     <option value="todo">todo</option>
                     <option value="ready">ready</option>
                     <option value="in_progress">in_progress</option>
+                    <option value="waiting_for_approval">waiting_for_approval</option>
                     <option value="review">review</option>
                     <option value="done">done</option>
                     <option value="dropped">dropped</option>
                     <option value="blocked">blocked</option>
+                    <option value="failed">failed</option>
                   </select>
                   <label class="force-label"><input id="moveForceCk" type="checkbox" />force</label>
                   <button class="secondary sm" onclick="moveTask(${t.id},null,null,null)">Move</button>
@@ -328,10 +355,12 @@
                     <option value="todo">todo</option>
                     <option value="ready">ready</option>
                     <option value="in_progress">in_progress</option>
+                    <option value="waiting_for_approval">waiting_for_approval</option>
                     <option value="review">review</option>
                     <option value="done">done</option>
                     <option value="dropped">dropped</option>
                     <option value="blocked">blocked</option>
+                    <option value="failed">failed</option>
                   </select>
                   <label class="force-label"><input id="moveForceCk" type="checkbox" />force</label>
                   <button class="secondary sm" onclick="moveTask(${t.id},null,null,null)">Move</button>
@@ -388,16 +417,31 @@
           <div class="detail-section">
             <div class="section-title">Signals</div>
             <div class="signal-grid">
-              ${signalCard('Progress', derived.latest_progress, 'signal-progress')}
-              ${signalCard('Handoff', derived.latest_handoff, 'signal-handoff')}
-              ${signalCard('Risk', derived.latest_risk, 'signal-risk')}
+              ${signalCard('Latest Progress', derived.latest_progress, 'signal-progress')}
+              ${signalCard('Latest Handoff', derived.latest_handoff, 'signal-handoff')}
+              ${signalCard('Latest Risk', derived.latest_risk, 'signal-risk')}
             </div>
             ${recommendedActions.length ? `
               <div class="recommended-actions">
-                <span class="rec-label">Suggested:</span>
+                <span class="rec-label">Recommended Actions</span>
                 ${recommendedActions.map(a => `<span class="action-tag">${a.label || a.id || '-'}</span>`).join('')}
               </div>
             ` : ''}
+          </div>
+        ` : ''}
+
+        ${dependencies.length ? `
+          <div class="detail-section">
+            <div class="section-title">Dependencies</div>
+            ${dependencies.map(d => `
+              <div class="run-card">
+                <span class="run-id">#${d.blocked_task_id}</span>
+                <span>${d.blocked_title}</span>
+                <span class="meta-chip">${d.kind}</span>
+                <span class="run-id">#${d.blocking_task_id}</span>
+                <span>${d.blocking_title}</span>
+              </div>
+            `).join('')}
           </div>
         ` : ''}
 
@@ -504,6 +548,8 @@
       const to = e.status_to || '';
       if (to === 'done') return 'tl-done';
       if (to === 'blocked') return 'tl-blocked';
+      if (to === 'waiting_for_approval') return 'tl-blocked';
+      if (to === 'failed') return 'tl-blocked';
       if (to === 'in_progress') return 'tl-in_progress';
       if (to === 'review') return 'tl-review';
       if (to === 'ready') return 'tl-ready';

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -33,6 +33,92 @@ class StoreTests(unittest.TestCase):
         tasks = self.store.list_tasks("kthena")
         self.assertEqual(task_id, tasks[0].id)
         self.assertEqual("controller partition revision bug", tasks[0].title)
+        self.assertEqual("task", tasks[0].issue_type)
+        self.assertEqual("medium", tasks[0].risk_level)
+
+    def test_add_task_accepts_jira_lite_issue_fields(self) -> None:
+        self.store.create_project("demo", "example/demo")
+        task_id = self.store.add_task(
+            project="demo",
+            title="approve external publish",
+            description="agent needs to post a summary",
+            issue_type="incident",
+            priority=5,
+            impact=5,
+            effort=2,
+            success_criteria="human approval is recorded before posting",
+            risk_level="critical",
+            reporter="ops-lead",
+            environment="prod",
+            source="manual",
+            external_id="approval-1",
+        )
+
+        task = self.store.get_task(task_id)
+        assert task is not None
+        self.assertEqual("incident", task.issue_type)
+        self.assertEqual("critical", task.risk_level)
+        self.assertEqual("ops-lead", task.reporter)
+        self.assertEqual("prod", task.environment)
+        self.assertEqual("human approval is recorded before posting", task.success_criteria)
+
+    def test_task_dependencies_are_project_scoped(self) -> None:
+        self.store.create_project("demo", "example/demo")
+        blocker_id = self.store.add_task(
+            project="demo",
+            title="finish auth migration",
+            description=None,
+            priority=4,
+            impact=4,
+            effort=3,
+            source=None,
+            external_id=None,
+        )
+        blocked_id = self.store.add_task(
+            project="demo",
+            title="ship dashboard",
+            description=None,
+            priority=4,
+            impact=4,
+            effort=2,
+            source=None,
+            external_id=None,
+        )
+
+        dep_id = self.store.add_task_dependency(blocked_id, blocker_id, "depends_on")
+        deps = self.store.list_task_dependencies(blocked_id)
+
+        self.assertGreater(dep_id, 0)
+        self.assertEqual(1, len(deps))
+        self.assertEqual(blocked_id, int(deps[0]["blocked_task_id"]))
+        self.assertEqual(blocker_id, int(deps[0]["blocking_task_id"]))
+        self.assertEqual("depends_on", deps[0]["kind"])
+
+    def test_agent_native_statuses_can_flow_through_approval_and_failure(self) -> None:
+        self.store.create_project("demo", "example/demo")
+        task_id = self.store.add_task(
+            project="demo",
+            title="approval task",
+            description=None,
+            priority=3,
+            impact=3,
+            effort=2,
+            source=None,
+            external_id=None,
+        )
+
+        self.store.move_task(task_id, "ready", "ready")
+        self.store.move_task(task_id, "in_progress", "claimed")
+        self.store.move_task(task_id, "waiting_for_approval", "needs approval")
+        task = self.store.get_task(task_id)
+        assert task is not None
+        self.assertEqual("waiting_for_approval", task.status)
+
+        self.store.move_task(task_id, "failed", "approval timed out")
+        self.store.move_task(task_id, "ready", "retry")
+        task = self.store.get_task(task_id)
+        assert task is not None
+        self.assertEqual("ready", task.status)
 
     def test_next_task_ranking(self) -> None:
         self.store.create_project("demo", None)


### PR DESCRIPTION
## Summary

Implements the first slice of #62: Jira-inspired, agent-native task semantics while preserving the existing lightweight board model.

## Changes

- Adds task issue fields: `issue_type`, `success_criteria`, `risk_level`, `reporter`, and `environment`
- Adds a `task_dependencies` table with project-scoped dependency validation
- Adds agent-native statuses: `waiting_for_approval` and `failed`
- Extends store transitions, CLI task creation/board output, markdown/dashboard exports, and console task details
- Shows issue type, risk, success criteria, dependencies, approval/failure states, and related actions in the console
- Adds migration coverage and store tests for issue fields, dependencies, and new statuses

## Validation

- `PYTHONPATH=src python3 -m unittest discover -s tests`

Closes #62